### PR TITLE
The code and output tab is visible now.

### DIFF
--- a/lib/src/home/widgets/editor.dart
+++ b/lib/src/home/widgets/editor.dart
@@ -87,6 +87,7 @@ class _EditorWidgetState extends ConsumerState<EditorWidget>
         children: [
           if (ref.watch(tabVisibilityProvider))
             TabBar(
+              labelColor: Colors.black,
               tabs: const [Tab(text: 'Code'), Tab(text: 'Output')],
               controller: _tabController,
             ),

--- a/lib/src/home/widgets/output.dart
+++ b/lib/src/home/widgets/output.dart
@@ -93,7 +93,10 @@ class _OutputWidget extends ConsumerWidget {
         child: ListView(
           children: [
             _OutputListItem(
-                icon: Icons.code, title: 'Output', content: data['output']),
+              icon: Icons.code,
+              title: 'Output',
+              content: data['output'],
+            ),
             _OutputListItem(
                 icon: Icons.error, title: 'Error', content: data['err']),
           ],
@@ -132,7 +135,10 @@ class _OutputListItem extends StatelessWidget {
           children: [
             ListTile(
               leading: Icon(icon),
-              title: Text(title),
+              title: Text(
+                title,
+                style: const TextStyle(color: Colors.black),
+              ),
             ),
             Align(
               alignment: Alignment.centerLeft,

--- a/lib/src/home/widgets/output.dart
+++ b/lib/src/home/widgets/output.dart
@@ -135,10 +135,7 @@ class _OutputListItem extends StatelessWidget {
           children: [
             ListTile(
               leading: Icon(icon),
-              title: Text(
-                title,
-                style: const TextStyle(color: Colors.black),
-              ),
+              title: Text(title),
             ),
             Align(
               alignment: Alignment.centerLeft,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96297602/196505742-70f387a9-3ba2-4271-b39c-c85815cd660f.png)
